### PR TITLE
feat: find graphql file in first level of sub directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typescript": "2.7.2"
   },
   "dependencies": {
+    "fs-finder": "^1.8.1",
     "graphql-import": "^0.4.4",
     "graphql-request": "^1.5.0",
     "js-yaml": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "typescript": "2.7.2"
   },
   "dependencies": {
-    "fs-finder": "^1.8.1",
     "graphql-import": "^0.4.4",
     "graphql-request": "^1.5.0",
     "js-yaml": "^3.10.0",

--- a/src/__tests__/basic/findGraphQLConfigFile.ts
+++ b/src/__tests__/basic/findGraphQLConfigFile.ts
@@ -10,6 +10,10 @@ test('returns a correct config filename', (t) => {
   t.deepEqual(configFile, join(__dirname, '.graphqlconfig'))
 });
 
+test('returns a correct config filename for 1st level of sub directories', (t) => {
+  const configFile = findGraphQLConfigFile(`${__dirname}/../sub-directory-config`)
+  t.deepEqual(configFile, join(`${__dirname}/../sub-directory-config/sub-directory-2`, '.graphqlconfig'))
+});
 
 test('throws GraphQLConfigNotFoundError when config is not found', (t) => {
   const tempDir = mkdtempSync(join(tmpdir(), 'graphql-config'))

--- a/src/__tests__/sub-directory-config/sub-directory-2/.graphqlconfig
+++ b/src/__tests__/sub-directory-config/sub-directory-2/.graphqlconfig
@@ -1,0 +1,3 @@
+{
+  "schemaPath": "../schema.json"
+}


### PR DESCRIPTION
This is required for https://github.com/prismagraphql/vscode-graphql
to work with mono-repo like projects where graphql config file might be
in a sub directory.

Currently, we return the first graphql config file found. However, there
can be multiple of them.